### PR TITLE
Support terminals with dark backgrounds

### DIFF
--- a/src/components/ProcessTable.jsx
+++ b/src/components/ProcessTable.jsx
@@ -63,6 +63,8 @@ function cellData(header, value) {
   switch (header) {
     case 'state':
       if (value !== 'RUNNING') {
+        // TODO(jeff): Figure out how to maintain this when the row is selected. Weird that it
+        // doesn’t' work like in `ProcessSummary`.
         value = `{red-fg}${value}{/}`;
       }
   }
@@ -201,8 +203,7 @@ export default class ProcessTable extends Component {
           focused
           align='left'
           style={{
-            item: { fg: 'black' },
-            selected: { fg: 'white', bg: 'black' },
+            selected: { inverse: true },
             header: { bold: true }
           }}
           tags // Enables cell content to contain color tags.

--- a/src/components/processDetails/ProcessSummary.jsx
+++ b/src/components/processDetails/ProcessSummary.jsx
@@ -23,9 +23,9 @@ export default function ProcessSummary({ process }) {
     switch (key) {
       case 'state':
         if (value !== 'RUNNING') {
-          // Note that this doesn't preserve the black background--text colors aren't composited,
-          // apparently. We could fix this by wrapping in `{black-bg}` but I think it's better for
-          // contrast to have white background.
+          // Note that this doesn't preserve the inverted background--text colors aren't composited,
+          // apparently. We could fix this by wrapping in a background-color tag but I think it's
+          // better for contrast to have the normal background.
           value = `{red-fg}${value}{/red-fg}`;
         }
     }
@@ -39,7 +39,7 @@ export default function ProcessSummary({ process }) {
       tags // Enables cell content to contain color tags.
       style={{
         // Mimics the selection in the process table.
-        header: { fg: 'white', bg: 'black' }
+        header: { inverse: true }
       }}
       height={1}
     />


### PR DESCRIPTION
Thank goodness `inverse` is a thing, because Googling “how to detect
terminal background color” did not look promising. `inverse` is more explicit
and simpler anyhow.

Fixes https://github.com/mixmaxhq/custody/issues/24.