### PR TITLE
Don’t corrupt `process.name`

### DIFF
--- a/src/components/ProcessTable.jsx
+++ b/src/components/ProcessTable.jsx
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import { effectiveState } from '../utils/process';
+import { displayName, effectiveState } from '../utils/process';
 import fuzzy from 'fuzzy';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
@@ -13,7 +13,7 @@ function getDerivedProcessesFromProps({ processes }) {
     return {
       ...process,
       // Rename the process to mimic `supervisorctl status`.
-      name: (process.group === process.name) ? process.name : `${process.group}:${process.name}`
+      displayName: displayName(process)
     };
   });
 }
@@ -22,7 +22,7 @@ function filterProcesses(search, processes) {
   return fuzzy.filter(search, processes, {
     pre: '{underline}',
     post: '{/underline}',
-    extract: (process) => process.name
+    extract: (process) => process.displayName
   }).map((result) => {
     return {
       ...result.original,

--- a/src/components/processDetails/ProcessSummary.jsx
+++ b/src/components/processDetails/ProcessSummary.jsx
@@ -1,4 +1,4 @@
-import { effectiveState } from '../../utils/process';
+import { displayName, effectiveState } from '../../utils/process';
 import { HEADERS } from '../ProcessTable';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -9,6 +9,9 @@ export default function ProcessSummary({ process }) {
 
     // Derive the data.
     switch (key) {
+      case 'name':
+        value = displayName(process);
+        break;
       // For state and description, prefer information reported by the child process if available.
       case 'state':
       case 'description':

--- a/src/utils/process.js
+++ b/src/utils/process.js
@@ -4,6 +4,18 @@ import { promisify } from 'promise-callbacks';
 const exec = promisify(require('child_process').exec);
 
 /**
+ * Returns a name for the process that mimics that shown by `supervisorctl status`, incorporating
+ * both the process' name and its group (if any).
+ *
+ * @param {Object} process - The process.
+ *
+ * @return {String} The display name.
+ */
+export function displayName(process) {
+  return (process.group === process.name) ? process.name : `${process.group}:${process.name}`;
+}
+
+/**
  * States of a process' lifecycle.
  */
 export const STATES = {


### PR DESCRIPTION
This would prevent selecting processes within groups, since we would select
e.g. “tools:kibana” (the display name) and then fail to keep that selected when
the process was refreshed with its actual name, “kibana”.