### PR TITLE
Remove `Esc` as a shortcut for quitting the program

### DIFF
--- a/src/components/ProcessTable.jsx
+++ b/src/components/ProcessTable.jsx
@@ -150,23 +150,15 @@ export default class ProcessTable extends Component {
           terminalIndex = 0;
         }
         const newSearch = prevState.search.slice(0, terminalIndex);
-        if (!newSearch) {
-          // Release Esc.
-          screen.grabKeys = false;
-        }
         return ProcessTable.getDerivedStateFromProps(props, { ...prevState, search: newSearch });
       });
 
     } else if (key.full === 'escape') {
-      // Release Esc.
-      screen.grabKeys = false;
       this.setState(ProcessTable.getDerivedStateFromProps(this.props, { ...this.state, search: '' }));
 
     } else if (ch && !_.contains(['enter', 'return'], key.name)) {
       this.setState((prevState, props) => {
         const newSearch = prevState.search + ch;
-        // Grab Esc to clear the search, instead of quitting the program.
-        screen.grabKeys = true;
         return ProcessTable.getDerivedStateFromProps(props, { ...prevState, search: newSearch });
       });
     }

--- a/src/components/processDetails/index.jsx
+++ b/src/components/processDetails/index.jsx
@@ -7,19 +7,11 @@ import screen from '../../screen';
 
 export default class ProcessDetails extends Component {
   componentDidMount() {
-    // Grab Esc to use in navigation, instead of quitting the program.
-    screen.grabKeys = true;
-
     // The log has to be focused--not our root element--in order to enable keyboard navigation
     // thereof. But then this means that we have to listen for the log's keypress events, using the
     // special bubbling syntax https://github.com/chjj/blessed#event-bubbling, and have to do so
     // manually (ugh): https://github.com/Yomguithereal/react-blessed/issues/61
     this.el.on('element keypress', ::this.onElementKeypress);
-  }
-
-  componentWillUnmount() {
-    // Release Esc.
-    screen.grabKeys = false;
   }
 
   onElementKeypress(el, ch, key) {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -26,8 +26,8 @@ export default async function start({ port, notifications }) {
   renderApp();
   processMonitor.on('update', renderApp);
 
-  screen.key(['escape', 'C-c'], () => process.exit(0));
+  screen.key(['C-c'], () => process.exit(0));
 
-  // Allow components to lock Esc for use in navigation, but not Ctrl-C (exit) or F12 (debug log).
+  // Don't allow components to lock-out our control keys, Ctrl-C (exit) and F12 (debug log).
   screen.ignoreLocked = ['C-c', 'f12'];
 }


### PR DESCRIPTION
Since it's too easy to quit the program when closing the logs.

Fixes https://github.com/mixmaxhq/custody/issues/40.