### PR TITLE
Properly log fatal errors to the console

### DIFF
--- a/bin/custody-cli.js
+++ b/bin/custody-cli.js
@@ -23,7 +23,13 @@ const argv = require('yargs')
   .alias('h', 'help')
   .argv;
 
-custody(argv).catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+custody(argv)
+  .then(() => process.exit(0))
+  .catch((err) => {
+    if (err.code === 'ECONNREFUSED') {
+      console.error(`Error: Supervisor is not running on port ${argv.port}.`);
+    } else {
+      console.error(err);
+    }
+    process.exit(1);
+  });


### PR DESCRIPTION
They were being hidden previously because we didn’t reset the terminal before
logging and exited immediately after logging, before the logs would overwrite
blessed’s buffer.

We also nicely-format the primary source of fatal errors, Supervisor not
running.

Fixes https://github.com/mixmaxhq/custody/issues/47.