### PR TITLE
Float the process controls over the logs

### DIFF
--- a/src/components/processDetails/ProcessControls.jsx
+++ b/src/components/processDetails/ProcessControls.jsx
@@ -38,7 +38,9 @@ export default class ProcessControls extends Component {
     // HACK(jeff): We don't know for sure that the control manipulates the process.
     // But it's a fair bet.
     const process = this.props.process;
-    control.toggle().catch((err) => {
+
+    // `Promise.resolve` the result of `toggle` to support both synchronous and asynchronous actions.
+    Promise.resolve(control.toggle()).catch((err) => {
       screen.debug(`Could not ${control.verb} ${process.name}:`, err);
     });
   }

--- a/src/components/processDetails/ProcessControls.jsx
+++ b/src/components/processDetails/ProcessControls.jsx
@@ -35,12 +35,12 @@ export default class ProcessControls extends Component {
     const control = this.state.controls.get(ch);
     if (!control) return;
 
-    // HACK(jeff): We don't know for sure that the control manipulates the process.
-    // But it's a fair bet.
     const process = this.props.process;
 
     // `Promise.resolve` the result of `toggle` to support both synchronous and asynchronous actions.
     Promise.resolve(control.toggle()).catch((err) => {
+      // HACK(jeff): We don't know for sure that the control manipulates the process.
+      // But it's a fair bet.
       screen.debug(`Could not ${control.verb} ${process.name}:`, err);
     });
   }

--- a/src/components/processDetails/index.jsx
+++ b/src/components/processDetails/index.jsx
@@ -8,7 +8,7 @@ const DEFAULT_CONTROLS = [
   ['Esc', {
     verb: 'go back',
     toggle() {
-      // Nothing to do since we already handle escape above.
+      // Nothing to do since we already handle escape in `onElementKeypress` below.
     }
   }]
 ];

--- a/src/components/processDetails/index.jsx
+++ b/src/components/processDetails/index.jsx
@@ -4,6 +4,15 @@ import Log from './ProcessLog';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
+const DEFAULT_CONTROLS = [
+  ['Esc', {
+    verb: 'go back',
+    toggle() {
+      // Nothing to do since we already handle escape above.
+    }
+  }]
+];
+
 export default class ProcessDetails extends Component {
   componentDidMount() {
     // The log has to be focused--not our root element--in order to enable keyboard navigation
@@ -30,20 +39,12 @@ export default class ProcessDetails extends Component {
           process={this.props.process}
           focused
           /* HACK(jeff): `top` === the `height` of `Summary`. */
-          layout={{ top: 1, height: '100%-3' }}
+          layout={{ top: 1 }}
         />
         <Controls
           ref={(controls) => this.controls = controls}
           process={this.props.process}
-          layout={{ top: '100%-2' }}
-          controls={[
-            ['Esc', {
-              verb: 'go back',
-              toggle() {
-                // Nothing to do since we already handle escape above.
-              }
-            }]
-          ]}
+          controls={DEFAULT_CONTROLS}
         />
       </box>
     );


### PR DESCRIPTION
And stack them vertically, and let the user toggle the controls by pressing ‘/‘.

This
* gives more space to the logs
* lets us more easily add additional controls, now that the descriptions are
  stacked vertically rather than horizontally
* lets the user Cmd-K clear the logs without permanently hiding the controls
  (#38), since the user can press
  the toggle button to reshow the controls

Note that the user will have to toggle twice if the controls had been shown before clearing, since custody will not know that the controls are no longer visible.

I wish we could detect the user holding down Cmd, to pre-emptively hide the controls before the user pressed K, to eliminate the double-toggle, but I can't figure out how to do this if it is possible, `keypress` listeners will not receive an event for the modifier key alone.

Anyhow, it might be less likely that the controls are visible when the user presses Cmd-K now that the user can hide the controls.