### PR TITLE
Add support for vi navigation commands in file logs.

### DIFF
--- a/src/components/FileLog.jsx
+++ b/src/components/FileLog.jsx
@@ -90,13 +90,16 @@ export default class FileLog extends Component {
         // blessed's mouse handling while this component is mounted to let the terminal take over
         // scrolling.
         keys
+        // Enable vi-style navigation. Implemented here:
+        // https://github.com/chjj/blessed/blob/eab243fc7ad27f1d2932db6134f7382825ee3488/lib/widgets/scrollablebox.js
+        // Supported navigation keys:
+        // -  k,  j: up, down
+        // - ctl+u, ctl+d: half-page up, half-page down
+        // - ctl+b, ctl+f: page up, page down
+        // - shift+g, g: jump to bottom, jump to top.
+        vi
         focused={this.props.focused}
         scrollback={SCROLLBACK}
-        // TODO(jeff): Enable pinning to the bottom of the logs. Possible using the `scrollOnInput`
-        // prop, just requires us to give the user a keyboard shortcut to do so. Not totally sure
-        // this is necessary though since the component will follow the logs if the user is scrolled
-        // to the bottom--sounds like enabling this would only jump the user to the end if they had
-        // scrolled away.
       />
     );
   }


### PR DESCRIPTION
I really like the `ctl+d` and `ctl+u` navigation shortcuts available in vim and other UNIX text editors. It looks like the authors of react-blessed liked them too, since they have [built-in support for vi navigation](https://github.com/chjj/blessed#scrollabletext-from-scrollablebox) in their view elements :)

The ScrollableBox api has a vi navigation option that adds support for a few of the most common vi navigation shortcuts: https://github.com/chjj/blessed/blob/eab243fc7ad27f1d2932db6134f7382825ee3488/lib/widgets/scrollablebox.js#L119
The ScrollableBox component is officially deprecated, but the log component that we use in our FileLog component is not. For now we can hope that the vi prop on the log component won't be removed in a future version.

https://github.com/mixmaxhq/custody/commit/b0b6e863729c401212f0e7644070f086ab00ae94 enables vi navigation for all file logs. If desired, we could also add a plugin or global command that lets the user enable and disable vi navigation.