### PR TITLE
Make it possible for the user to navigate directly between recent processes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,21 @@
         "js-tokens": "^3.0.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
+      "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
+      }
+    },
     "@babel/template": {
       "version": "7.0.0-beta.44",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
@@ -2202,6 +2217,19 @@
         "sntp": "2.x.x"
       }
     },
+    "history": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.9.0.tgz",
+      "integrity": "sha512-H2DkjCjXf0Op9OAr6nJ56fcRkTSNrUiv41vNJ6IswJjif6wlpZK0BTfFbi7qK9dXLSYZxkq5lBsj3vUjlYBYZA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^2.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^0.4.0"
+      }
+    },
     "hoek": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
@@ -3492,6 +3520,11 @@
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
       "dev": true
     },
+    "resolve-pathname": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
+      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
+    },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -3951,6 +3984,16 @@
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
+    "tiny-invariant": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.4.tgz",
+      "integrity": "sha512-lMhRd/djQJ3MoaHEBrw8e2/uM4rs9YMNk0iOr8rHQ0QdbM7D4l0gFl3szKdeixrlyfm9Zqi4dxHCM2qVG8ND5g=="
+    },
+    "tiny-warning": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.2.tgz",
+      "integrity": "sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -4097,6 +4140,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
+      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel-plugin-syntax-object-rest-spread": "^6.13.0",
     "blessed": "github:mixmaxhq/blessed#dc5d6b916bc1eb8183ec7b4c053c0622aabd8e52",
     "fuzzy": "^0.1.3",
+    "history": "^4.9.0",
     "ini": "^1.3.5",
     "kexec": "^3.0.0",
     "lodash.xor": "^4.5.0",

--- a/src/components/Console.jsx
+++ b/src/components/Console.jsx
@@ -242,9 +242,9 @@ export default class Console extends Component {
   }
 
   onSelect(newProcess) {
-    const newPath = history.formatPath({
+    const newLocation = {
       process: newProcess.name
-    });
+    };
 
     // Since we don't represent the process table in the history, we may navigate to the same
     // location twice if the user closes and then reopens the same process. Make sure that we
@@ -254,14 +254,14 @@ export default class Console extends Component {
     if (!currentLocation) {
       locationIsNew = true;
     } else {
-      locationIsNew = newPath !== `${currentLocation.pathname}${currentLocation.search}${currentLocation.hash}`;
+      locationIsNew = newLocation.process !== currentLocation.process;
     }
 
     // This will set `selectedProcess` via `onLocationChange` whether we `push` OR `replace`.
     if (locationIsNew) {
-      history.push(newPath);
+      history.push(newLocation);
     } else {
-      history.replace(newPath);
+      history.replace(newLocation);
     }
   }
 

--- a/src/components/Console.jsx
+++ b/src/components/Console.jsx
@@ -1,7 +1,9 @@
 import _ from 'underscore';
+import { getBackCommand, getForwardCommand } from '/models/commands/navigation';
 import CommandMenu from '/components/commandMenu/index';
 import commands, {addCommandSet, removeCommandSet} from '/components/commandMenu/commands';
 import FileLog from './FileLog';
+import * as history from '/utils/history';
 import { promisify } from 'promise-callbacks';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
@@ -42,6 +44,9 @@ function processHasChangedState(prevProps) {
 const COMMAND_SET_NAME = 'console';
 
 function getCommandSet(component) {
+  // NOTE: If you reference any new properties of `component.state` below, make sure to call
+  // `updateOwnCommandSet` from `componentDidUpdate` if/when that state changes.
+
   let maintailDescription;
   if (component.state.tailingMainLogfile) {
     maintailDescription = 'switch to/{underline}from{/} maintail';
@@ -49,14 +54,18 @@ function getCommandSet(component) {
     maintailDescription = 'switch {underline}to{/}/from maintail';
   }
 
-  return [
+  return _.compact([
+    // The navigation commands are for switching between selected processes so only show them if
+    // we're currently displaying an individual process.
+    !component.state.tailingMainLogfile && getBackCommand(),
+    !component.state.tailingMainLogfile && getForwardCommand(),
     ['tab', {
       verb: maintailDescription,
       toggle() {
         component.setState(({ tailingMainLogfile }) => ({ tailingMainLogfile: !tailingMainLogfile }));
       }
     }]
-  ];
+  ]);
 }
 
 export default class Console extends Component {
@@ -90,8 +99,14 @@ export default class Console extends Component {
     this.setState({commands: removeCommandSet(name)});
   }
 
-  componentDidMount() {
+  updateOwnCommandSet() {
     this.addCommandSet(COMMAND_SET_NAME, getCommandSet(this));
+  }
+
+  componentDidMount() {
+    this.updateOwnCommandSet();
+
+    this._unlistenToHistory = history.listen(::this.onLocationChange);
 
     // Our various children have to be focused--not our root element--in order to enable keyboard
     // navigation thereof. But then this means that we have to listen for the children's keypress
@@ -129,7 +144,23 @@ export default class Console extends Component {
   }
 
   componentWillUnmount() {
+    if (this._unlistenToHistory) {
+      this._unlistenToHistory();
+      this._unlistenToHistory = null;
+    }
     this.removeCommandSet(COMMAND_SET_NAME);
+  }
+
+  onLocationChange({ process: processName }) {
+    const selectedProcess = _.findWhere(this.props.processes, {
+      name: processName
+    });
+
+    // This conditional is safety belts--we always assume locations to reference processes for the
+    // moment.
+    if (selectedProcess) this.setState({ selectedProcess });
+
+    this.updateOwnCommandSet();
   }
 
   // Whatever keys we handle here, should also be withheld from the process table in
@@ -175,7 +206,8 @@ export default class Console extends Component {
     }
 
     if (this.state.tailingMainLogfile !== prevState.tailingMainLogfile) {
-      this.addCommandSet(COMMAND_SET_NAME, getCommandSet(this));
+      // Update the commands when state values they reference change.
+      this.updateOwnCommandSet();
     }
   }
 
@@ -209,11 +241,33 @@ export default class Console extends Component {
     });
   }
 
-  onSelect(process) {
-    this.setState({ selectedProcess: process });
+  onSelect(newProcess) {
+    const newPath = history.formatPath({
+      process: newProcess.name
+    });
+
+    // Since we don't represent the process table in the history, we may navigate to the same
+    // location twice if the user closes and then reopens the same process. Make sure that we
+    // avoid creating a duplicate history item in this case.
+    const currentLocation = history.currentLocation();
+    let locationIsNew;
+    if (!currentLocation) {
+      locationIsNew = true;
+    } else {
+      locationIsNew = newPath !== `${currentLocation.pathname}${currentLocation.search}${currentLocation.hash}`;
+    }
+
+    // This will set `selectedProcess` via `onLocationChange` whether we `push` OR `replace`.
+    if (locationIsNew) {
+      history.push(newPath);
+    } else {
+      history.replace(newPath);
+    }
   }
 
   onDeselect() {
+    // HACK(jeff): We don't include the process table in the history, allowing the user to navigate
+    // directly between selected processes.
     this.setState({ selectedProcess: null });
   }
 

--- a/src/components/FileLog.jsx
+++ b/src/components/FileLog.jsx
@@ -24,6 +24,17 @@ export default class FileLog extends Component {
     enableMouse(true);
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.logfile !== prevProps.logfile) {
+      this.stopTailing();
+
+      // Clear the existing logs. I couldn't find a higher-level "clear" or "reset" API.
+      this.log.setContent('');
+
+      this.startTailing();
+    }
+  }
+
   startTailing() {
     // Safety belts.
     if (this.tail) return;

--- a/src/components/commandMenu/commands.js
+++ b/src/components/commandMenu/commands.js
@@ -11,6 +11,9 @@
 /**
  * @typedef {Object} CommandDescription
  *
+ * @property {String=} displayName - The string to use to represent the command trigger in the
+ *   command menu. Defaults to the first argument of the `Command` array--specify this key if you
+ *   want to override that for some reason.
  * @property {String} verb - A description of what the command does, of the form
  *   "<action> [<subject>]". Examples: 'restart' or "show/hide commands".
  * @property {AsyncFunction|Function} toggle - A function that, when invoked, will perform the

--- a/src/components/commandMenu/index.jsx
+++ b/src/components/commandMenu/index.jsx
@@ -77,8 +77,8 @@ export default class CommandMenu extends Component {
     if (this.state.hidden) return null;
 
     let boxContent = [...this.commands]
-      .map(([ch, {verb, isSeparator}]) => {
-        return isSeparator ? '' : `'${ch}' to ${verb}`;
+      .map(([ch, {displayName = ch, verb, isSeparator}]) => {
+        return isSeparator ? '' : `'${displayName}' to ${verb}`;
       })
       .join('\n');
 

--- a/src/models/commands/navigation.js
+++ b/src/models/commands/navigation.js
@@ -1,0 +1,39 @@
+import * as history from '/utils/history';
+
+export function getBackCommand() {
+  const previousLocation = history.previousLocation();
+  if (!previousLocation) return null;
+
+  const { process: previousProcessName } = history.parsePath(previousLocation.pathname);
+
+  // This conditional is safety belts--we always assume locations to reference processes for the
+  // moment.
+  if (!previousProcessName) return null;
+
+  return ['left', {
+    displayName: '←',
+    verb: `switch to "${previousProcessName}"`,
+    toggle() {
+      history.goBack();
+    }
+  }];
+}
+
+export function getForwardCommand() {
+  const nextLocation = history.nextLocation();
+  if (!nextLocation) return null;
+
+  const { process: nextProcessName } = history.parsePath(nextLocation.pathname);
+
+  // This conditional is safety belts--we always assume locations to reference processes for the
+  // moment.
+  if (!nextProcessName) return null;
+
+  return ['right', {
+    displayName: '→',
+    verb: `switch to "${nextProcessName}"`,
+    toggle() {
+      history.goForward();
+    }
+  }];
+}

--- a/src/models/commands/navigation.js
+++ b/src/models/commands/navigation.js
@@ -4,7 +4,7 @@ export function getBackCommand() {
   const previousLocation = history.previousLocation();
   if (!previousLocation) return null;
 
-  const { process: previousProcessName } = history.parsePath(previousLocation.pathname);
+  const { process: previousProcessName } = previousLocation;
 
   // This conditional is safety belts--we always assume locations to reference processes for the
   // moment.
@@ -23,7 +23,7 @@ export function getForwardCommand() {
   const nextLocation = history.nextLocation();
   if (!nextLocation) return null;
 
-  const { process: nextProcessName } = history.parsePath(nextLocation.pathname);
+  const { process: nextProcessName } = nextLocation;
 
   // This conditional is safety belts--we always assume locations to reference processes for the
   // moment.

--- a/src/utils/history.js
+++ b/src/utils/history.js
@@ -1,0 +1,71 @@
+import { createMemoryHistory } from 'history';
+
+const history = createMemoryHistory({
+  // Don't include any initial entry since we don't include the process table in the history.
+  initialEntries: []
+});
+
+/* Navigation */
+
+export function listen(listener) {
+  return history.listen((location) => {
+    listener(parsePath(location.pathname));
+  });
+}
+
+export function push(path) {
+  history.push(path);
+}
+
+// Note that this will still trigger listeners.
+export function replace(path) {
+  history.replace(path);
+}
+
+export function currentLocation() {
+  // Will return `undefined` to start, since we initialize it with `initialEntries: []`.
+  return history.location;
+}
+
+export function previousLocation() {
+  return history.entries[history.index - 1];
+}
+
+export function canGoBack() {
+  return history.canGo(-1);
+}
+
+export function goBack() {
+  history.goBack();
+}
+
+export function nextLocation() {
+  return history.entries[history.index + 1];
+}
+
+export function canGoForward() {
+  return history.canGo(1);
+}
+
+export function goForward() {
+  history.goForward();
+}
+
+/* Path formatting and parsing */
+
+export function formatPath({ process }) {
+  // One way to extend this function for additional sorts of locations: add keys to the arguments
+  // object, with each key representing the type of path and expecting only one of the keys to
+  // be defined for any call.
+  //
+  // Let's say we added a key "view", with the signature becoming `{ process, view }`. We would then
+  // return `/process/${process}` if `process` was defined, otherwise return `/view/${view}`.
+  return `/process/${process}`;
+}
+
+export function parsePath(path) {
+  const components = path.match(/^\/(.+?)\/(.+?)$/);
+  if (!components) throw new Error(`path was not formatted using formatPath: "${path}"`);
+
+  return { [components[1]]: components[2] };
+}

--- a/src/utils/history.js
+++ b/src/utils/history.js
@@ -13,22 +13,35 @@ export function listen(listener) {
   });
 }
 
-export function push(path) {
-  history.push(path);
+/**
+ * @param {String} process - The name of a process.
+ */
+export function push({ process }) {
+  history.push(formatPath({ process }));
 }
 
-// Note that this will still trigger listeners.
-export function replace(path) {
-  history.replace(path);
+/**
+ * Note that this will still trigger listeners.
+ *
+ * @param {String} process - The name of a process.
+ */
+export function replace({ process }) {
+  history.replace(formatPath({ process }));
 }
 
 export function currentLocation() {
   // Will return `undefined` to start, since we initialize it with `initialEntries: []`.
-  return history.location;
+  const rawLocation = history.location;
+  if (!rawLocation) return null;
+
+  return parsePath(rawLocation.pathname);
 }
 
 export function previousLocation() {
-  return history.entries[history.index - 1];
+  const rawLocation = history.entries[history.index - 1];
+  if (!rawLocation) return null;
+
+  return parsePath(rawLocation.pathname);
 }
 
 export function canGoBack() {
@@ -40,7 +53,10 @@ export function goBack() {
 }
 
 export function nextLocation() {
-  return history.entries[history.index + 1];
+  const rawLocation = history.entries[history.index + 1];
+  if (!rawLocation) return null;
+
+  return parsePath(rawLocation.pathname);
 }
 
 export function canGoForward() {
@@ -53,7 +69,7 @@ export function goForward() {
 
 /* Path formatting and parsing */
 
-export function formatPath({ process }) {
+function formatPath({ process }) {
   // One way to extend this function for additional sorts of locations: add keys to the arguments
   // object, with each key representing the type of path and expecting only one of the keys to
   // be defined for any call.
@@ -63,7 +79,7 @@ export function formatPath({ process }) {
   return `/process/${process}`;
 }
 
-export function parsePath(path) {
+function parsePath(path) {
   const components = path.match(/^\/(.+?)\/(.+?)$/);
   if (!components) throw new Error(`path was not formatted using formatPath: "${path}"`);
 


### PR DESCRIPTION
By keeping track of the user’s history of selected processes, and adding
commands to the console command set for navigating that history.

The process table and maintail views are intentionally not represented in the
history, for the moment, so that the user may navigate directly between
selected processes.